### PR TITLE
fix the css import processing regexp bug

### DIFF
--- a/jawr/jawr-core/src/main/java/net/jawr/web/resource/bundle/postprocess/impl/CSSImportPostProcessor.java
+++ b/jawr/jawr-core/src/main/java/net/jawr/web/resource/bundle/postprocess/impl/CSSImportPostProcessor.java
@@ -52,7 +52,7 @@ public class CSSImportPostProcessor extends
 	
 	/** The url pattern */
 	private static final Pattern IMPORT_PATTERN = Pattern.compile(	"@import\\s*url\\(\\s*" // 'url(' and any number of whitespaces 
-																+ "[\"']?([^\"']*)[\"']?" // any sequence of characters, except an unescaped ')'
+																+ "[\"']?([^\"')]*)[\"']?" // any sequence of characters, except an unescaped ')'
 																+ "\\s*\\)\\s*(\\w+)?\\s*;?",  // Any number of whitespaces, then ')'
 																Pattern.CASE_INSENSITIVE); // works with 'URL('
 	

--- a/jawr/jawr-core/src/test/java/test/net/jawr/web/resource/bundle/postprocess/impl/CSSImportPostProcessorTest.java
+++ b/jawr/jawr-core/src/test/java/test/net/jawr/web/resource/bundle/postprocess/impl/CSSImportPostProcessorTest.java
@@ -144,6 +144,24 @@ public class CSSImportPostProcessorTest {
 	}
 	
 	@Test
+	public void testBasicRelativeURLImport1() {
+		// basic test
+		StringBuffer data = new StringBuffer("@import url(temp.css);\n" +
+				".blue { color : rgb(0, 0, 255) } ");
+
+		String filePath = "/css/folder/subfolder/subfolder/someCSS.css";
+		String expectedContent = ".test { align : left; \n" +
+						"padding : 0 7px; \n" +
+						"background : url('../img/rainbow.png'); \n"+
+				"}\n" +
+				".blue { color : rgb(0, 0, 255) } ";
+
+		status = getBundleProcessingStatus(filePath, "/css/folder/subfolder/subfolder/temp.css");
+		String result = processor.postProcessBundle(status, data).toString();
+		assertEquals("Content was not rewritten properly",expectedContent, result);
+	}
+
+	@Test
 	public void testRelativeURLImportWithSpaceAndSimpleQuote() {
 		// basic test
 		StringBuffer data = new StringBuffer("@import url( \n 'temp.css' \n );\n" +


### PR DESCRIPTION
This fixes a long standing bug in the jawr css import processing, where the imported file name is not properly extracted because the `IMPORT_PATTERN` regex may grab more than it should for the file name. 

The new test `testBasicRelativeURLImport1` demonstrates the bug (it's a simple modification of the `testBasicRelativeURLImport` test where `#0000FF` is replaced by `rgb(0, 0, 255)`, which trggers the bug because of the closing parenthesis)