### PR TITLE
remove the final qualifier from AbstractBundleLinkRenderer.addComment

### DIFF
--- a/jawr/jawr-core/src/main/java/net/jawr/web/resource/bundle/renderer/AbstractBundleLinkRenderer.java
+++ b/jawr/jawr-core/src/main/java/net/jawr/web/resource/bundle/renderer/AbstractBundleLinkRenderer.java
@@ -366,7 +366,7 @@ public abstract class AbstractBundleLinkRenderer implements BundleRenderer {
 	 * @throws IOException
 	 *             if an IO exception occurs
 	 */
-	protected final void addComment(String commentText, Writer out)
+	protected void addComment(String commentText, Writer out)
 			throws IOException {
 		StringBuffer sb = new StringBuffer(
 				"<script type=\"text/javascript\">/* ");


### PR DESCRIPTION
Hopefully there is no strong reason to keep it final, as we would like to override it.