### PR TITLE
add a "/" to the default coffee-script.js location

### DIFF
--- a/jawr/jawr-core/src/main/java/net/jawr/web/resource/bundle/generator/js/coffee/CoffeeScriptGenerator.java
+++ b/jawr/jawr-core/src/main/java/net/jawr/web/resource/bundle/generator/js/coffee/CoffeeScriptGenerator.java
@@ -57,7 +57,7 @@ public class CoffeeScriptGenerator extends AbstractJavascriptGenerator
 	private static final String JAWR_JS_GENERATOR_COFFEE_SCRIPT_LOCATION = "jawr.js.generator.coffee.script.location";
 
 	/** The default coffee script JS location */
-	private static final String DEFAULT_COFFEE_SCRIPT_JS_LOCATION = "net/jawr/web/resource/bundle/generator/js/coffee/coffee-script.js";
+	private static final String DEFAULT_COFFEE_SCRIPT_JS_LOCATION = "/net/jawr/web/resource/bundle/generator/js/coffee/coffee-script.js";
 
 	/** The resolver */
 	private ResourceGeneratorResolver resolver;


### PR DESCRIPTION
This problem shows up under tomcat 8: without the "/", instead of returning null, `ServletContext.getResourceAsStream` throws `IllegalArgumentException`, so it doesn't get a chance to fall back to `ClassLoaderResourceUtils.getResourceAsStream`