### PR TITLE
log more errors in JawrServlet

### DIFF
--- a/jawr/jawr-core/src/main/java/net/jawr/web/servlet/JawrServlet.java
+++ b/jawr/jawr-core/src/main/java/net/jawr/web/servlet/JawrServlet.java
@@ -74,7 +74,7 @@ public class JawrServlet extends HttpServlet implements ServletContextListener {
 			LOGGER.error(fatal, "Cause:");
 			LOGGER.error(fatal, e.getMessage(), e);
 			throw e;
-		} catch (RuntimeException e) {
+		} catch (Throwable e) {
 			Marker fatal = MarkerFactory.getMarker("FATAL");
 			LOGGER.error(fatal, "Jawr servlet with name "
 					+ getServletConfig().getServletName()


### PR DESCRIPTION
currently `JawrServlet` logs `RuntimeExceptions` in `init()`. Other errors,  such as `NoClassDefFoundError`, which may be thrown if rhino, lesscss or some other jars are missing in a project, could occur with no obvious indication in the application logs what went wrong with JAWR. This patch makes `JawrServlet` log any error.