### PR TITLE
Support webjars-locator if class is present

### DIFF
--- a/jawr/jawr-core/pom.xml
+++ b/jawr/jawr-core/pom.xml
@@ -94,6 +94,12 @@
 			<artifactId>im4java</artifactId>
 			<scope>provided</scope>
 		</dependency>
+		<!-- optional webjars locator dependency -->
+		<dependency>
+			<groupId>org.webjars</groupId>
+			<artifactId>webjars-locator-core</artifactId>
+			<optional>true</optional>
+		</dependency>
 		<!-- webjars dependencies used for webjars generator test -->
 		<dependency>
 			<groupId>org.webjars</groupId>

--- a/jawr/jawr-core/src/main/java/net/jawr/web/resource/bundle/factory/util/ClassLoaderResourceUtils.java
+++ b/jawr/jawr-core/src/main/java/net/jawr/web/resource/bundle/factory/util/ClassLoaderResourceUtils.java
@@ -272,6 +272,22 @@ public class ClassLoaderResourceUtils {
 	}
 
 	/**
+	 * Checks whether the class is present.
+	 *
+	 * @param classname  the name of class to be checked
+	 * @return true if the class is present.
+	 */
+	public static boolean isClassPresent(String classname) {
+		try {
+			Class.forName(classname);
+			return true;
+		} catch (ClassNotFoundException e) {
+
+		}
+		return false;
+	}
+
+	/**
 	 * Returns the class associated to the class name given in parameter
 	 * 
 	 * @param classname

--- a/jawr/jawr-core/src/main/java/net/jawr/web/resource/bundle/generator/GeneratorRegistry.java
+++ b/jawr/jawr-core/src/main/java/net/jawr/web/resource/bundle/generator/GeneratorRegistry.java
@@ -37,6 +37,9 @@ import net.jawr.web.resource.bundle.generator.classpath.ClasspathJSGenerator;
 import net.jawr.web.resource.bundle.generator.classpath.webjars.WebJarsBinaryResourceGenerator;
 import net.jawr.web.resource.bundle.generator.classpath.webjars.WebJarsCssGenerator;
 import net.jawr.web.resource.bundle.generator.classpath.webjars.WebJarsJSGenerator;
+import net.jawr.web.resource.bundle.generator.classpath.webjars.WebJarsLocatorBinaryResourceGenerator;
+import net.jawr.web.resource.bundle.generator.classpath.webjars.WebJarsLocatorCssGenerator;
+import net.jawr.web.resource.bundle.generator.classpath.webjars.WebJarsLocatorJSGenerator;
 import net.jawr.web.resource.bundle.generator.css.less.LessCssGenerator;
 import net.jawr.web.resource.bundle.generator.img.SpriteGenerator;
 import net.jawr.web.resource.bundle.generator.js.coffee.CoffeeScriptGenerator;
@@ -88,6 +91,9 @@ public class GeneratorRegistry implements Serializable {
 
 	/** The webjars generator prefix */
 	public static final String WEBJARS_GENERATOR_PREFIX = "webjars";
+
+	/** The webjars asset locator classname*/
+	public static final String WEBJARS_LOCATOR_CLASSNAME = "org.webjars.WebJarAssetLocator";
 
 	/** The commons validator bundle prefix */
 	public static final String COMMONS_VALIDATOR_PREFIX = "acv";
@@ -160,15 +166,34 @@ public class GeneratorRegistry implements Serializable {
 				ResourceBundleMessagesGenerator.class);
 		Class<?> classPathGeneratorClass = null;
 		Class<?> webJarsGeneratorClass = null;
+
+		boolean isWebJarsLocatorPresent = ClassLoaderResourceUtils
+				.isClassPresent(WEBJARS_LOCATOR_CLASSNAME);
+
 		if (resourceType.equals(JawrConstant.JS_TYPE)) {
 			classPathGeneratorClass = ClasspathJSGenerator.class;
-			webJarsGeneratorClass = WebJarsJSGenerator.class;
+			if (isWebJarsLocatorPresent) {
+				webJarsGeneratorClass = WebJarsLocatorJSGenerator.class;
+			}
+			else {
+				webJarsGeneratorClass = WebJarsJSGenerator.class;
+			}
 		} else if (resourceType.equals(JawrConstant.CSS_TYPE)) {
 			classPathGeneratorClass = ClassPathCSSGenerator.class;
-			webJarsGeneratorClass = WebJarsCssGenerator.class;
+			if (isWebJarsLocatorPresent) {
+				webJarsGeneratorClass = WebJarsLocatorCssGenerator.class;
+			}
+			else {
+				webJarsGeneratorClass = WebJarsCssGenerator.class;
+			}
 		} else {
 			classPathGeneratorClass = ClassPathImgResourceGenerator.class;
-			webJarsGeneratorClass = WebJarsBinaryResourceGenerator.class;
+			if (isWebJarsLocatorPresent) {
+				webJarsGeneratorClass = WebJarsLocatorBinaryResourceGenerator.class;
+			}
+			else {
+				webJarsGeneratorClass = WebJarsBinaryResourceGenerator.class;
+			}
 		}
 
 		commonGenerators.put(new PrefixedPathResolver(

--- a/jawr/jawr-core/src/main/java/net/jawr/web/resource/bundle/generator/classpath/ClassPathCSSGenerator.java
+++ b/jawr/jawr-core/src/main/java/net/jawr/web/resource/bundle/generator/classpath/ClassPathCSSGenerator.java
@@ -77,8 +77,17 @@ public class ClassPathCSSGenerator extends AbstractCSSGenerator implements
 	 */
 	public ClassPathCSSGenerator() {
 		helper = new ClassPathGeneratorHelper(getClassPathGeneratorHelperPrefix());
-		resolver = ResourceGeneratorResolverFactory
-				.createPrefixResolver(getGeneratorPrefix());
+		resolver = createResolver(getGeneratorPrefix());
+	}
+
+	/**
+	 * create the resource generator resolver
+	 *
+	 * @param  generatorPrefix the generator prefix
+	 * @return the resource generator resolver
+	 */
+	protected ResourceGeneratorResolver createResolver(String generatorPrefix) {
+		return ResourceGeneratorResolverFactory.createPrefixResolver(generatorPrefix);
 	}
 
 	/**

--- a/jawr/jawr-core/src/main/java/net/jawr/web/resource/bundle/generator/classpath/ClassPathImgResourceGenerator.java
+++ b/jawr/jawr-core/src/main/java/net/jawr/web/resource/bundle/generator/classpath/ClassPathImgResourceGenerator.java
@@ -47,8 +47,17 @@ public class ClassPathImgResourceGenerator implements StreamResourceGenerator {
 	public ClassPathImgResourceGenerator() {
 		helper = new ClassPathGeneratorHelper(
 				getClassPathGeneratorHelperPrefix());
-		resolver = ResourceGeneratorResolverFactory
-				.createPrefixResolver(getGeneratorPrefix());
+		resolver = createResolver(getGeneratorPrefix());
+	}
+
+	/**
+	 * create the resource generator resolver
+	 *
+	 * @param  generatorPrefix the generator prefix
+	 * @return the resource generator resolver
+	 */
+	protected ResourceGeneratorResolver createResolver(String generatorPrefix) {
+		return ResourceGeneratorResolverFactory.createPrefixResolver(generatorPrefix);
 	}
 
 	/**

--- a/jawr/jawr-core/src/main/java/net/jawr/web/resource/bundle/generator/classpath/ClasspathJSGenerator.java
+++ b/jawr/jawr-core/src/main/java/net/jawr/web/resource/bundle/generator/classpath/ClasspathJSGenerator.java
@@ -45,8 +45,17 @@ public class ClasspathJSGenerator extends AbstractJavascriptGenerator {
 	 */
 	public ClasspathJSGenerator() {
 		helper = new ClassPathGeneratorHelper(getClassPathGeneratorHelperPrefix());
-		resolver = ResourceGeneratorResolverFactory
-				.createPrefixResolver(getGeneratorPrefix());
+		resolver = createResolver(getGeneratorPrefix());
+	}
+
+	/**
+	 * create the resource generator resolver
+	 *
+	 * @param  generatorPrefix the generator prefix
+	 * @return the resource generator resolver
+	 */
+	protected ResourceGeneratorResolver createResolver(String generatorPrefix) {
+		return ResourceGeneratorResolverFactory.createPrefixResolver(generatorPrefix);
 	}
 
 	/**

--- a/jawr/jawr-core/src/main/java/net/jawr/web/resource/bundle/generator/classpath/webjars/WebJarsJSGenerator.java
+++ b/jawr/jawr-core/src/main/java/net/jawr/web/resource/bundle/generator/classpath/webjars/WebJarsJSGenerator.java
@@ -14,9 +14,7 @@
 package net.jawr.web.resource.bundle.generator.classpath.webjars;
 
 import net.jawr.web.resource.bundle.generator.GeneratorRegistry;
-import net.jawr.web.resource.bundle.generator.classpath.ClassPathGeneratorHelper;
 import net.jawr.web.resource.bundle.generator.classpath.ClasspathJSGenerator;
-import net.jawr.web.resource.bundle.generator.resolver.ResourceGeneratorResolverFactory;
 
 /**
  * This class defines the generator for webjar JS resources
@@ -29,9 +27,7 @@ public class WebJarsJSGenerator extends ClasspathJSGenerator {
 	 * Constructor
 	 */
 	public WebJarsJSGenerator() {
-		helper = new ClassPathGeneratorHelper(getClassPathGeneratorHelperPrefix());
-		resolver = ResourceGeneratorResolverFactory
-				.createPrefixResolver(getGeneratorPrefix());
+
 	}
 
 	/* (non-Javadoc)

--- a/jawr/jawr-core/src/main/java/net/jawr/web/resource/bundle/generator/classpath/webjars/WebJarsLocatorBinaryResourceGenerator.java
+++ b/jawr/jawr-core/src/main/java/net/jawr/web/resource/bundle/generator/classpath/webjars/WebJarsLocatorBinaryResourceGenerator.java
@@ -1,0 +1,16 @@
+package net.jawr.web.resource.bundle.generator.classpath.webjars;
+
+import net.jawr.web.resource.bundle.generator.resolver.ResourceGeneratorResolver;
+import net.jawr.web.resource.bundle.generator.resolver.WebJarsLocatorPathResolver;
+
+public class WebJarsLocatorBinaryResourceGenerator extends WebJarsBinaryResourceGenerator {
+
+    /* (non-Javadoc)
+     * @see net.jawr.web.resource.bundle.generator.classpath.ClassPathImgResourceGenerator#createResolver(java.lang.String)
+     */
+    @Override
+    protected ResourceGeneratorResolver createResolver(String generatorPrefix) {
+        return new WebJarsLocatorPathResolver(generatorPrefix);
+    }
+
+}

--- a/jawr/jawr-core/src/main/java/net/jawr/web/resource/bundle/generator/classpath/webjars/WebJarsLocatorCssGenerator.java
+++ b/jawr/jawr-core/src/main/java/net/jawr/web/resource/bundle/generator/classpath/webjars/WebJarsLocatorCssGenerator.java
@@ -1,0 +1,16 @@
+package net.jawr.web.resource.bundle.generator.classpath.webjars;
+
+import net.jawr.web.resource.bundle.generator.resolver.ResourceGeneratorResolver;
+import net.jawr.web.resource.bundle.generator.resolver.WebJarsLocatorPathResolver;
+
+public class WebJarsLocatorCssGenerator extends WebJarsCssGenerator {
+
+    /* (non-Javadoc)
+     * @see net.jawr.web.resource.bundle.generator.classpath.ClassPathCSSGenerator#createResolver(java.lang.String)
+     */
+    @Override
+    protected ResourceGeneratorResolver createResolver(String generatorPrefix) {
+        return new WebJarsLocatorPathResolver(generatorPrefix);
+    }
+
+}

--- a/jawr/jawr-core/src/main/java/net/jawr/web/resource/bundle/generator/classpath/webjars/WebJarsLocatorJSGenerator.java
+++ b/jawr/jawr-core/src/main/java/net/jawr/web/resource/bundle/generator/classpath/webjars/WebJarsLocatorJSGenerator.java
@@ -1,0 +1,16 @@
+package net.jawr.web.resource.bundle.generator.classpath.webjars;
+
+import net.jawr.web.resource.bundle.generator.resolver.ResourceGeneratorResolver;
+import net.jawr.web.resource.bundle.generator.resolver.WebJarsLocatorPathResolver;
+
+public class WebJarsLocatorJSGenerator extends WebJarsJSGenerator {
+
+    /* (non-Javadoc)
+     * @see net.jawr.web.resource.bundle.generator.classpath.ClasspathJSGenerator#createResolver(java.lang.String)
+     */
+    @Override
+    protected ResourceGeneratorResolver createResolver(String generatorPrefix) {
+        return new WebJarsLocatorPathResolver(generatorPrefix);
+    }
+
+}

--- a/jawr/jawr-core/src/main/java/net/jawr/web/resource/bundle/generator/resolver/WebJarsLocatorPathResolver.java
+++ b/jawr/jawr-core/src/main/java/net/jawr/web/resource/bundle/generator/resolver/WebJarsLocatorPathResolver.java
@@ -1,0 +1,30 @@
+package net.jawr.web.resource.bundle.generator.resolver;
+
+import net.jawr.web.resource.bundle.generator.GeneratorRegistry;
+import org.webjars.WebJarAssetLocator;
+
+public class WebJarsLocatorPathResolver extends PrefixedPathResolver {
+
+    private final WebJarAssetLocator locator;
+
+    /**
+     * Constructor
+     *
+     * @param prefix  the path prefix
+     */
+    public WebJarsLocatorPathResolver(String prefix) {
+        super(prefix);
+        this.locator = new WebJarAssetLocator();
+    }
+
+    /* (non-Javadoc)
+     * @see net.jawr.web.resource.bundle.generator.resolver.PrefixedPathResolver#getResourcePath(java.lang.String)
+     */
+    @Override
+    public String getResourcePath(String requestedPath) {
+        String resourcePath = super.getResourcePath(requestedPath);
+        resourcePath = locator.getFullPath(resourcePath);
+        return resourcePath.substring(GeneratorRegistry.WEBJARS_GENERATOR_HELPER_PREFIX.length() - 2);
+    }
+
+}

--- a/jawr/jawr-core/src/test/java/test/net/jawr/web/resource/bundle/generator/classpath/webjars/WebJarsBinaryGeneratorTestCase.java
+++ b/jawr/jawr-core/src/test/java/test/net/jawr/web/resource/bundle/generator/classpath/webjars/WebJarsBinaryGeneratorTestCase.java
@@ -32,11 +32,17 @@ public class WebJarsBinaryGeneratorTestCase {
 	@Before
 	public void setUp() throws Exception {
 
-		final String resourcePath = "/bootstrap/3.2.0/fonts/glyphicons-halflings-regular.eot";
-
-		generator = new WebJarsBinaryResourceGenerator();
-		ctx = new GeneratorContext(config, resourcePath);
+		generator = createGenerator();
+		ctx = new GeneratorContext(config, generator.getResolver().getResourcePath(getResourceName()));
 		ctx.setResourceReaderHandler(rsReaderHandler);
+	}
+
+	protected String getResourceName() {
+		return "webjars:/bootstrap/3.2.0/fonts/glyphicons-halflings-regular.eot";
+	}
+
+	protected WebJarsBinaryResourceGenerator createGenerator() {
+		return new WebJarsBinaryResourceGenerator();
 	}
 
 	@Test

--- a/jawr/jawr-core/src/test/java/test/net/jawr/web/resource/bundle/generator/classpath/webjars/WebJarsCssGeneratorTestCase.java
+++ b/jawr/jawr-core/src/test/java/test/net/jawr/web/resource/bundle/generator/classpath/webjars/WebJarsCssGeneratorTestCase.java
@@ -61,9 +61,6 @@ public class WebJarsCssGeneratorTestCase {
 		FileUtils.clearDirectory(FileUtils.getClasspathRootDir()+"/"+WORK_DIR);
 		FileUtils.createDir(WORK_DIR);
 		
-		// Bundle path (full url would be: /servletMapping/prefix/css/bundle.css
-		final String bundlePath = "/bootstrap/3.2.0/css/bootstrap.css";
-		
 		Properties props = new Properties();
 		props.put("jawr.css.classpath.handle.image", "true");
 		config = new JawrConfig(JawrConstant.CSS_TYPE, props);
@@ -76,8 +73,8 @@ public class WebJarsCssGeneratorTestCase {
 		
 		config.setGeneratorRegistry(generatorRegistry);
 		
-		generator = new WebJarsCssGenerator();
-		ctx = new GeneratorContext(config, bundlePath);
+		generator = createGenerator();
+		ctx = new GeneratorContext(config, generator.getResolver().getResourcePath(getResourceName()));
 		ctx.setResourceReaderHandler(rsReaderHandler);
 		
 		// Set up the Image servlet Jawr config
@@ -106,12 +103,20 @@ public class WebJarsCssGeneratorTestCase {
 		
 		generator.setWorkingDirectory(FileUtils.getClasspathRootDir()+"/"+WORK_DIR);
 	}
-	
+
+	protected String getResourceName() {
+		return "webjars:/bootstrap/3.2.0/css/bootstrap.css";
+	}
+
+	protected WebJarsCssGenerator createGenerator() {
+		return new WebJarsCssGenerator();
+	}
+
 	@After
 	public void tearDown() throws Exception{
 		FileUtils.deleteDirectory(FileUtils.getClasspathRootDir()+"/"+WORK_DIR);
 	}
-	
+
 	@Test
 	public void testWebJarsCssBundleGenerator() throws Exception{
 		

--- a/jawr/jawr-core/src/test/java/test/net/jawr/web/resource/bundle/generator/classpath/webjars/WebJarsJsGeneratorTestCase.java
+++ b/jawr/jawr-core/src/test/java/test/net/jawr/web/resource/bundle/generator/classpath/webjars/WebJarsJsGeneratorTestCase.java
@@ -39,8 +39,6 @@ public class WebJarsJsGeneratorTestCase {
 	@Before
 	public void setUp() throws Exception {
 
-		final String bundlePath = "/bootstrap/3.2.0/js/bootstrap.js";
-
 		config = new JawrConfig(JawrConstant.JS_TYPE, new Properties());
 		ServletContext servletContext = new MockServletContext();
 
@@ -50,9 +48,17 @@ public class WebJarsJsGeneratorTestCase {
 
 		config.setGeneratorRegistry(generatorRegistry);
 
-		generator = new WebJarsJSGenerator();
-		ctx = new GeneratorContext(config, bundlePath);
+		generator = createGenerator();
+		ctx = new GeneratorContext(config, generator.getResolver().getResourcePath(getResourceName()));
 		ctx.setResourceReaderHandler(rsReaderHandler);
+	}
+
+	protected String getResourceName() {
+		return "webjars:/bootstrap/3.2.0/js/bootstrap.js";
+	}
+
+	protected WebJarsJSGenerator createGenerator() {
+		return new WebJarsJSGenerator();
 	}
 
 	@Test

--- a/jawr/jawr-core/src/test/java/test/net/jawr/web/resource/bundle/generator/classpath/webjars/WebJarsLocatorBinaryGeneratorTestCase.java
+++ b/jawr/jawr-core/src/test/java/test/net/jawr/web/resource/bundle/generator/classpath/webjars/WebJarsLocatorBinaryGeneratorTestCase.java
@@ -1,0 +1,18 @@
+package test.net.jawr.web.resource.bundle.generator.classpath.webjars;
+
+import net.jawr.web.resource.bundle.generator.classpath.webjars.WebJarsBinaryResourceGenerator;
+import net.jawr.web.resource.bundle.generator.classpath.webjars.WebJarsLocatorBinaryResourceGenerator;
+
+public class WebJarsLocatorBinaryGeneratorTestCase extends WebJarsBinaryGeneratorTestCase {
+
+    @Override
+    protected String getResourceName() {
+        return "webjars:glyphicons-halflings-regular.eot";
+    }
+
+    @Override
+    protected WebJarsBinaryResourceGenerator createGenerator() {
+        return new WebJarsLocatorBinaryResourceGenerator();
+    }
+
+}

--- a/jawr/jawr-core/src/test/java/test/net/jawr/web/resource/bundle/generator/classpath/webjars/WebJarsLocatorCssGeneratorTestCase.java
+++ b/jawr/jawr-core/src/test/java/test/net/jawr/web/resource/bundle/generator/classpath/webjars/WebJarsLocatorCssGeneratorTestCase.java
@@ -1,0 +1,18 @@
+package test.net.jawr.web.resource.bundle.generator.classpath.webjars;
+
+import net.jawr.web.resource.bundle.generator.classpath.webjars.WebJarsCssGenerator;
+import net.jawr.web.resource.bundle.generator.classpath.webjars.WebJarsLocatorCssGenerator;
+
+public class WebJarsLocatorCssGeneratorTestCase extends WebJarsCssGeneratorTestCase {
+
+    @Override
+    protected String getResourceName() {
+        return "webjars:bootstrap.css";
+    }
+
+    @Override
+    protected WebJarsCssGenerator createGenerator() {
+        return new WebJarsLocatorCssGenerator();
+    }
+
+}

--- a/jawr/jawr-core/src/test/java/test/net/jawr/web/resource/bundle/generator/classpath/webjars/WebJarsLocatorJsGeneratorTestCase.java
+++ b/jawr/jawr-core/src/test/java/test/net/jawr/web/resource/bundle/generator/classpath/webjars/WebJarsLocatorJsGeneratorTestCase.java
@@ -1,0 +1,18 @@
+package test.net.jawr.web.resource.bundle.generator.classpath.webjars;
+
+import net.jawr.web.resource.bundle.generator.classpath.webjars.WebJarsJSGenerator;
+import net.jawr.web.resource.bundle.generator.classpath.webjars.WebJarsLocatorJSGenerator;
+
+public class WebJarsLocatorJsGeneratorTestCase extends WebJarsJsGeneratorTestCase {
+
+    @Override
+    protected String getResourceName() {
+        return "webjars:bootstrap.js";
+    }
+
+    @Override
+    protected WebJarsJSGenerator createGenerator() {
+        return new WebJarsLocatorJSGenerator();
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
 		<im4java.version>1.4.0</im4java.version>
 		<jetty.version>9.2.6.v20141205</jetty.version>
 		<htmlunit.version>2.5</htmlunit.version>
+		<webjars-locator.version>0.27</webjars-locator.version>
 		<jquery-version>1.11.1</jquery-version>
 		<bootstrap-version>3.2.0</bootstrap-version>
 		<wicket.version>6.10.0</wicket.version>
@@ -274,6 +275,14 @@
 				<artifactId>jackson-datatype-json-org</artifactId>
 				<version>${jackson-json.version}</version>
 				<scope>provided</scope>
+			</dependency>
+
+			<!-- Optional Webjars Locator dependency -->
+			<dependency>
+				<groupId>org.webjars</groupId>
+				<artifactId>webjars-locator-core</artifactId>
+				<version>${webjars-locator.version}</version>
+				<optional>true</optional>
 			</dependency>
 
 			<dependency>


### PR DESCRIPTION
Support webjars-locator if 'org.webjars.WebJarAssetLocator' is present. Make it easier to manage the resource. 
For example, if the user's pom includes:
```
<dependency>
    <groupId>org.webjars</groupId>
    <artifactId>webjars-locator-core</artifactId>
    <version>0.27</version>
</dependency>
<dependency>
    <groupId>org.webjars</groupId>
    <artifactId>jquery</artifactId>
    <version>2.1.4</version>
</dependency>
```
then **webjars:jquery.js** will automatically locate the resource instead of **webjars:/jquery/2.1.4/jquery.js**

https://github.com/webjars/webjars-locator-core