### PR TITLE
Remove log4j dependency for jawr-spring-extension

### DIFF
--- a/jawr-spring/jawr-spring-extension/pom.xml
+++ b/jawr-spring/jawr-spring-extension/pom.xml
@@ -33,11 +33,6 @@
 			<artifactId>servlet-api</artifactId>
 			<scope>provided</scope>
 		</dependency>
-		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<scope>provided</scope>
-		</dependency>
 
 	</dependencies>
 	<build>

--- a/jawr-spring/pom.xml
+++ b/jawr-spring/pom.xml
@@ -77,14 +77,6 @@
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-		</dependency>
 		<!-- Test dependencies -->
 		<dependency>
 			<groupId>junit</groupId>


### PR DESCRIPTION
Like jawr-core, jawr-spring-extension should not depend on Log4j, but only on SLF4J. Actually it doesn't seem to use Log4j, so I only removed log4j from pom.