### PR TITLE
Escape parens brackets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ target/
 .classpath
 .project
 
+#################
+## IntelliJ IDEA
+#################
+.idea
+*.iml

--- a/jawr-dwr2.x/.gitignore
+++ b/jawr-dwr2.x/.gitignore
@@ -28,6 +28,12 @@ local.properties
 # PDT-specific
 .buildpath
 
+#################
+## IntelliJ IDEA
+#################
+.idea
+*.iml
+
 #############
 ## Maven
 #############

--- a/jawr-dwr3.x/.gitignore
+++ b/jawr-dwr3.x/.gitignore
@@ -22,6 +22,11 @@ local.properties
 .cproject
 # PDT-specific
 .buildpath
+#################
+## IntelliJ IDEA
+#################
+.idea
+*.iml
 #############
 ## Maven
 #############

--- a/jawr/.gitignore
+++ b/jawr/.gitignore
@@ -2,3 +2,9 @@ target/
 .classpath
 .project
 .settings/
+
+#################
+## IntelliJ IDEA
+#################
+.idea
+*.iml

--- a/jawr/jawr-core/src/main/java/net/jawr/web/resource/bundle/generator/GeneratorMappingHelper.java
+++ b/jawr/jawr-core/src/main/java/net/jawr/web/resource/bundle/generator/GeneratorMappingHelper.java
@@ -27,6 +27,9 @@ public class GeneratorMappingHelper {
 	/** The brackets regexp finder */
 	private static final String BRACKFINDER_REGEXP = ".*(\\[.*\\]).*";
 
+	/** The string to use in the jawr.properties bundles to escape characters */
+	private static final String ESCAPE_STRING = "\\";
+
 	/** The path requested */
 	private String path;
 
@@ -38,25 +41,40 @@ public class GeneratorMappingHelper {
 
 	/**
 	 * Constructor
-	 * @param mapping the resource mapping
+	 * @param resourceMapping the resource mapping
 	 */
 	public GeneratorMappingHelper(String resourceMapping) {
-		this.path = resourceMapping;
+		path = resourceMapping;
+
+		String escapesRemoved = removeEscapedParenthesesAndBrackets(path);
+
 		// init parameters, if any
-		if (path.matches(PARENFINDER_REGEXP)) {
+		if (escapesRemoved.matches(PARENFINDER_REGEXP)) {
 			parenthesesParam = path.substring(path.indexOf('(') + 1,
 					path.indexOf(')'));
 
 			path = path.substring(0, path.indexOf('('))
 					+ path.substring(path.indexOf(')') + 1);
 		}
-		if (path.matches(BRACKFINDER_REGEXP)) {
+		if (escapesRemoved.matches(BRACKFINDER_REGEXP)) {
 			bracketsParam = path.substring(path.indexOf('[') + 1,
 					path.indexOf(']'));
 
 			path = path.substring(0, path.indexOf('['))
 					+ path.substring(path.indexOf(']') + 1);
 		}
+
+		if (!escapesRemoved.equals(path)) { // Had escaped brackets or parens
+			path = path.replace(ESCAPE_STRING, "");
+		}
+	}
+
+	private String removeEscapedParenthesesAndBrackets(String resourceMapping) {
+		return resourceMapping
+				.replace(ESCAPE_STRING + "(", "")
+				.replace(ESCAPE_STRING + ")", "")
+				.replace(ESCAPE_STRING + "[", "")
+				.replace(ESCAPE_STRING + "]", "");
 	}
 
 	/**

--- a/jawr/jawr-core/src/test/java/net/jawr/web/resource/bundle/generator/GeneratorMappingHelperTest.java
+++ b/jawr/jawr-core/src/test/java/net/jawr/web/resource/bundle/generator/GeneratorMappingHelperTest.java
@@ -69,4 +69,30 @@ public class GeneratorMappingHelperTest {
         assertNull(helper.getParenthesesParam());
     }
 
+    @Test
+    public void withEscapedParentheses() {
+        final String resource = "path/to/foo\\(\\).js";
+        final GeneratorMappingHelper helper = new GeneratorMappingHelper(resource);
+        assertEquals("path/to/foo().js", helper.getPath());
+        assertNull(helper.getParenthesesParam());
+        assertNull(helper.getBracketsParam());
+    }
+
+    @Test
+    public void withEscapedBrackets() {
+        final String resource = "path/to/foo\\[\\].js";
+        final GeneratorMappingHelper helper = new GeneratorMappingHelper(resource);
+        assertEquals("path/to/foo[].js", helper.getPath());
+        assertNull(helper.getParenthesesParam());
+        assertNull(helper.getBracketsParam());
+    }
+
+    @Test
+    public void withEscapedOther() {
+        final String resource = "path/to/foo\\|\\?.js";
+        final GeneratorMappingHelper helper = new GeneratorMappingHelper(resource);
+        assertEquals("path/to/foo\\|\\?.js", helper.getPath());
+        assertNull(helper.getParenthesesParam());
+        assertNull(helper.getBracketsParam());
+    }
 }

--- a/jawr/jawr-core/src/test/java/net/jawr/web/resource/bundle/generator/GeneratorMappingHelperTest.java
+++ b/jawr/jawr-core/src/test/java/net/jawr/web/resource/bundle/generator/GeneratorMappingHelperTest.java
@@ -1,0 +1,72 @@
+package net.jawr.web.resource.bundle.generator;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class GeneratorMappingHelperTest {
+
+    @Test
+    public void js() {
+        final String resource = "path/to/foo.js";
+        final GeneratorMappingHelper helper = new GeneratorMappingHelper(resource);
+        assertEquals(resource, helper.getPath());
+        assertNull(helper.getBracketsParam());
+        assertNull(helper.getParenthesesParam());
+    }
+
+    @Test
+    public void css() {
+        final String resource = "path/to/foo.css";
+        final GeneratorMappingHelper helper = new GeneratorMappingHelper(resource);
+        assertEquals(resource, helper.getPath());
+        assertNull(helper.getBracketsParam());
+        assertNull(helper.getParenthesesParam());
+    }
+
+    @Test
+    public void wildcard() {
+        final String resource = "path/to/*";
+        final GeneratorMappingHelper helper = new GeneratorMappingHelper(resource);
+        assertEquals(resource, helper.getPath());
+        assertNull(helper.getBracketsParam());
+        assertNull(helper.getParenthesesParam());
+    }
+
+    @Test
+    public void withParentheses() {
+        final String resource = "path/to/foo(bar).js";
+        final GeneratorMappingHelper helper = new GeneratorMappingHelper(resource);
+        assertEquals("path/to/foo.js", helper.getPath());
+        assertEquals("bar", helper.getParenthesesParam());
+        assertNull(helper.getBracketsParam());
+    }
+
+    @Test
+    public void withEmptyParentheses() {
+        final String resource = "path/to/foo().js";
+        final GeneratorMappingHelper helper = new GeneratorMappingHelper(resource);
+        assertEquals("path/to/foo.js", helper.getPath());
+        assertEquals("", helper.getParenthesesParam());
+        assertNull(helper.getBracketsParam());
+    }
+
+    @Test
+    public void withBrackets() {
+        final String resource = "path/to/foo[bar].js";
+        final GeneratorMappingHelper helper = new GeneratorMappingHelper(resource);
+        assertEquals("path/to/foo.js", helper.getPath());
+        assertEquals("bar", helper.getBracketsParam());
+        assertNull(helper.getParenthesesParam());
+    }
+
+    @Test
+    public void withEmptyBrackets() {
+        final String resource = "path/to/foo[].js";
+        final GeneratorMappingHelper helper = new GeneratorMappingHelper(resource);
+        assertEquals("path/to/foo.js", helper.getPath());
+        assertEquals("", helper.getBracketsParam());
+        assertNull(helper.getParenthesesParam());
+    }
+
+}


### PR DESCRIPTION
As noted in #21, you can't escape parentheses and/or brackets easily.  Here is a simple way to do it with tests that targets those characters only, since they have special meaning.  I can make changes if desired, just wanted to help out getting this into the main code line.