### PR TITLE
Remove context path override prefix when handling a request

### DIFF
--- a/jawr/jawr-core/src/main/java/net/jawr/web/servlet/JawrRequestHandler.java
+++ b/jawr/jawr-core/src/main/java/net/jawr/web/servlet/JawrRequestHandler.java
@@ -650,6 +650,8 @@ public class JawrRequestHandler implements ConfigChangeListener, Serializable {
 
 			String requestedPath = "".equals(jawrConfig.getServletMapping()) ? request.getServletPath()
 					: request.getPathInfo();
+			// Remove context override prefix from the requested path
+			requestedPath = removePathOverridePrefix(request, requestedPath);
 			processRequest(requestedPath, request, response);
 
 		} catch (Exception e) {
@@ -660,6 +662,26 @@ public class JawrRequestHandler implements ConfigChangeListener, Serializable {
 
 			throw new ServletException(e);
 		}
+	}
+
+	/**
+	 * Remove the context override prefix from the requestedPath
+	 *
+	 * @param request       the request
+	 * @param requestedPath the requested path
+	 * @return the requested path without the context override prefix
+	 */
+	public String removePathOverridePrefix(HttpServletRequest request, String requestedPath) {
+		String prefix;
+		if (request.isSecure()) {
+			prefix = jawrConfig.getContextPathSslOverride();
+		} else {
+			prefix = jawrConfig.getContextPathOverride();
+		}
+		if (prefix != null && requestedPath.startsWith(prefix)) {
+			return requestedPath.substring(prefix.length());
+		}
+		return requestedPath;
 	}
 
 	/**


### PR DESCRIPTION
When the context path override is used, binary resources are not resolved properly to real file path, because the prefix is not removed from the request.
For instance if the prefix is defined as "/prefix", the request to an image could be:

/prefix/cb4294738625/css/images/myimage.png

And the resource which is loaded is /prefix//css/images/myimage.png (after removing the cache buster part).

This PR removes the prefix as soon as the request comes in.
